### PR TITLE
Fix issue #1: Missing saved/unsaved status indicator of the note

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,35 +58,51 @@
         window.addEventListener('DOMContentLoaded', (event) => {
             let notepad = document.getElementById("notepad");
             let indicator = document.getElementById("status");
-
-            fs.readFile('/note', 'utf8', function (err, data) {
-                var str;
-                if (err) {
-                    str = "Welcome to my notepad!";
-                    notepad.innerHTML = str;
-                }
-                else if (data) {
-                    notepad.innerHTML = data;
-                }
-            });
-
-            //calls recently written save function every 2s
-            //var saveInterval = setInterval(save, 2000);
-            
-            notepad.addEventListener("input", event => {
-                indicator.innerHTML = "<strong>Note Unsaved</strong>. Press <i>Ctrl + S</i> to save.";
-                indicator.classList.replace("saved", "unsaved");
-            });
+            let oldvalue;
 
             //save function
             save = function() {
                 fs.writeFile('/note', document.querySelector('#notepad').innerHTML, (err) => {
                     if (err) throw err;
                     console.log('The file has been saved');
-                    indicator.innerHTML = "<strong>Note Saved!</strong>"
-                    indicator.classList.replace("unsaved", "saved");
+                    setIndicatorStatus("saved");
+                    oldvalue = notepad.innerHTML;
                 });
-            }
+            };
+
+            let setIndicatorStatus = function(status) {
+                if (status == "saved") {
+                    indicator.innerHTML = "<strong>Note Saved!</strong>";
+                    indicator.classList.replace("unsaved", "saved");
+                }
+                if (status == "unsaved") {
+                    indicator.innerHTML = "<strong>Note Unsaved</strong>. Press <i>Ctrl + S</i> to save.";
+                    indicator.classList.replace("saved", "unsaved");
+                }
+            };
+
+            fs.readFile('/note', 'utf8', function (err, data) {
+                var str;
+                if (err) {
+                    str = "Welcome to my notepad!";
+                    notepad.innerHTML = str;
+                    oldvalue = str;
+                }
+                else if (data) {
+                    notepad.innerHTML = data;
+                    oldvalue = data;
+                }
+            });
+
+            //calls recently written save function every 2s
+            //var saveInterval = setInterval(save, 2000);
+            notepad.addEventListener("input", event => {
+                if (oldvalue != event.target.innerHTML) {
+                    setIndicatorStatus("unsaved");
+                } else {
+                    setIndicatorStatus("saved");
+                }
+            });
         });
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>My Web Notepad</title>
     <link rel="stylesheet" href="https://unpkg.com/papercss@1.6.1/dist/paper.css">
     <style>
-        .status {
+        #status {
             padding: 2em;
         }
 
@@ -22,7 +22,7 @@
 <body>
     <main class="container">
         <div class="paper" id="notepad" contenteditable="true"></div>
-        <span id="status" class="status saved"><strong>Note Saved!</strong></span>
+        <span id="status" class="saved"><strong>Note Saved!</strong></span>
     </main>
 
     <script src="https://unpkg.com/filer/dist/filer.min.js"></script>
@@ -62,7 +62,7 @@
 
             //save function
             save = function() {
-                fs.writeFile('/note', document.querySelector('#notepad').innerHTML, (err) => {
+                fs.writeFile('/note', notepad.innerHTML, (err) => {
                     if (err) throw err;
                     console.log('The file has been saved');
                     setIndicatorStatus("saved");
@@ -82,9 +82,8 @@
             };
 
             fs.readFile('/note', 'utf8', function (err, data) {
-                var str;
                 if (err) {
-                    str = "Welcome to my notepad!";
+                    let str = "Welcome to my notepad!";
                     notepad.innerHTML = str;
                     oldvalue = str;
                 }
@@ -97,7 +96,7 @@
             //calls recently written save function every 2s
             //var saveInterval = setInterval(save, 2000);
             notepad.addEventListener("input", event => {
-                if (oldvalue != event.target.innerHTML) {
+                if (oldvalue != notepad.innerHTML) {
                     setIndicatorStatus("unsaved");
                 } else {
                     setIndicatorStatus("saved");

--- a/index.html
+++ b/index.html
@@ -4,62 +4,90 @@
     <meta charset="utf-8">
     <title>My Web Notepad</title>
     <link rel="stylesheet" href="https://unpkg.com/papercss@1.6.1/dist/paper.css">
+    <style>
+        .status {
+            padding: 2em;
+        }
+
+        .unsaved {
+            color: red;
+        }
+        
+        .saved {
+            color: green;
+        }
+    </style>
 </head>
 
 <body>
+    <main class="container">
+        <div class="paper" id="notepad" contenteditable="true"></div>
+        <span id="status" class="status saved"><strong>Note Saved!</strong></span>
+    </main>
+
     <script src="https://unpkg.com/filer/dist/filer.min.js"></script>
     <script src="https://unpkg.com/hotkeys-js/dist/hotkeys.min.js"></script>
-
-    <div class="paper container" id="notepad" contenteditable="true"></div>
     <script>
         const fs = new Filer.FileSystem();
 
         hotkeys.filter = function (event) {
             return true;
-        }
+        };
 
         //How to add the filter to edit labels. <div contentEditable="true"></div>
         //"contentEditable" Older browsers that do not support drops
         hotkeys.filter = function (event) {
             var tagName = (event.target || event.srcElement).tagName;
             return !(tagName.isContentEditable || tagName == 'INPUT' || tagName == 'SELECT' || tagName == 'TEXTAREA');
-        }
+        };
 
         hotkeys.filter = function (event) {
             var tagName = (event.target || event.srcElement).tagName;
             hotkeys.setScope(/^(INPUT|TEXTAREA|SELECT)$/.test(tagName) ? 'input' : 'other');
             return true;
-        }
+        };
 
+        var save;
         //prevents windows from trying to save html page and instead calls save function
         hotkeys('ctrl+s', function(){
             event.preventDefault();
             console.log('hotkey for save pressed (ctrl+s)');
             save();
-        })
+        });
 
         window.addEventListener('DOMContentLoaded', (event) => {
+            let notepad = document.getElementById("notepad");
+            let indicator = document.getElementById("status");
+
             fs.readFile('/note', 'utf8', function (err, data) {
                 var str;
                 if (err) {
                     str = "Welcome to my notepad!";
-                    document.querySelector('#notepad').innerHTML = str;
+                    notepad.innerHTML = str;
                 }
                 else if (data) {
-                    document.querySelector('#notepad').innerHTML = data;
+                    notepad.innerHTML = data;
                 }
-            })
+            });
+
             //calls recently written save function every 2s
             //var saveInterval = setInterval(save, 2000);
-        })
-
-        //save function
-        function save() {
-            fs.writeFile('/note', document.querySelector('#notepad').innerHTML, (err) => {
-                if (err) throw err;
-                console.log('The file has been saved');
+            
+            notepad.addEventListener("input", event => {
+                indicator.innerHTML = "<strong>Note Unsaved</strong>. Press <i>Ctrl + S</i> to save.";
+                indicator.classList.replace("saved", "unsaved");
             });
-        }
+
+            //save function
+            save = function() {
+                fs.writeFile('/note', document.querySelector('#notepad').innerHTML, (err) => {
+                    if (err) throw err;
+                    console.log('The file has been saved');
+                    indicator.innerHTML = "<strong>Note Saved!</strong>"
+                    indicator.classList.replace("unsaved", "saved");
+                });
+            }
+        });
     </script>
 </body>
 


### PR DESCRIPTION
I fixed issue #1 I created by adding a text indicator of the saved/unsaved status of the note.

When the app finishes loading, the indicator will be green showing the note is initially saved. However, an event listener is set on the notepad that when it receives user input, the indicator will turn red showing unsaved status of the note.

The event listener also checks if the text after being modified is different from the original. If it is not, the status indicator will turn back green.