### PR TITLE
Removed default text in 'status' span

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 <body>
     <main class="container">
         <div class="paper" id="notepad" contenteditable="true"></div>
-        <span id="status" class="saved"><strong>Note Saved!</strong></span>
+        <span id="status" class="saved"></span>
     </main>
 
     <script src="https://unpkg.com/filer/dist/filer.min.js"></script>


### PR DESCRIPTION
Web page no longer displays "Note saved" on opening